### PR TITLE
fix(readme): typo in release activites

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ name: ReleaseWorkflow
 
 on:
   release:
-    type: [published, prereleased]
+    types: [published, prereleased]
 
 
 jobs:


### PR DESCRIPTION
According to [docs](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#release-event-release), we should use `types` instead of `type` when specifying the activities.

```diff
on:
  release:
-   type: [published, prereleased]
+   types: [published, prereleased]
```