### PR TITLE
1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
     steps:
       - uses: actions/checkout@v1
       - run: npm ci

--- a/README.md
+++ b/README.md
@@ -27,11 +27,17 @@ Create a workflow `.yml` file in your repo's `.github/workflows` directory. An [
 
 #### `tagName`
 
-**Required** The name of release in Sentry.
+**Required** The tag being released. This is used as the Sentry release name. You can optionally prefix it using `releaseNamePrefix`.
 
 #### `environment`
 
 **Required** The name of the environment the release was deployed to.
+
+#### `releaseNamePrefix`
+
+**Optional** String that is prefixed to the tag to form the Sentry release name.
+
+> Please review Sentry's documentation regarding max length and supported characters in release names.
 
 For more information on these inputs, see the [API Documentation](https://developer.github.com/v3/repos/releases/#input)
 
@@ -97,6 +103,42 @@ jobs:
           tagName: ${{ github.ref }}
           environment: qa
 ```
+
+Assume you tagged your release as `v1.1.0`. `github.ref` would equal `refs/tags/v1.1.0`. This action automatically strips `refs/tags/`, so the Sentry release name is `v1.1.0`.
+
+### Example workflow with optional release prefix
+
+On every GitHub `release` event.
+
+```yaml
+name: ReleaseWorkflow
+
+on:
+  release:
+    types: [published, prereleased]
+
+
+jobs:
+  createSentryRelease:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Create a Sentry.io release
+        uses: tclindner/sentry-releases-action@v1.0.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: myAwesomeOrg
+          SENTRY_PROJECT: myAwesomeProject
+        with:
+          tagName: ${{ github.ref }}
+          environment: qa
+          releaseNamePrefix: myAwesomeProject-
+```
+
+Scenario 1: Assume you tagged your release as `v1.1.0`. `github.ref` would equal `refs/tags/v1.1.0`. This action automatically strips `refs/tags/`, so the Sentry release name is `myAwesomeProject-v1.1.0`.
+
+Scenario 2: Assume you tagged your release as `1.1.0` and you set `releaseNamePrefix` to `myAwesomeProject@`. `github.ref` would equal `refs/tags/1.1.0`. This action automatically strips `refs/tags/`, so the Sentry release name is `myAwesomeProject@1.1.0`.
 
 > Note: This action only works on Linux x86_64 systems.
 

--- a/action.yml
+++ b/action.yml
@@ -2,11 +2,14 @@ name: 'Create a Sentry.io release'
 description: 'Sentry.io releases for GitHub Actions'
 inputs:
   tagName:
-    description: 'Release version name'
+    description: 'Tag being released'
     required: true
   environment:
     description: 'Environment name'
     required: true
+  releaseNamePrefix:
+    description: 'String to prefix tagName with. Used as the Sentry release name.'
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,12 +7,12 @@ module.exports = {
       branches: 100,
       functions: 100,
       lines: 100,
-      statements: 100
-    }
+      statements: 100,
+    },
   },
   restoreMocks: true,
   resetMocks: true,
   resetModules: true,
   testEnvironment: 'node',
-  testPathIgnorePatterns: ['<rootDir>/node_modules/']
+  testPathIgnorePatterns: ['<rootDir>/node_modules/'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-releases-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2323,33 +2323,33 @@
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz",
-      "integrity": "sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.1.0.tgz",
+      "integrity": "sha512-+XCcfGyCnbzOnktDVhwsCAx+9DmrzEmuwxyHUJpw+kqBVT744OUBrB09khgFKlK1lshVww6qXGsYPZpavoNjJw==",
       "dev": true,
       "requires": {
-        "confusing-browser-globals": "^1.0.7",
+        "confusing-browser-globals": "^1.0.9",
         "object.assign": "^4.1.0",
-        "object.entries": "^1.1.0"
+        "object.entries": "^1.1.1"
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
       }
     },
     "eslint-config-tc": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-tc/-/eslint-config-tc-11.0.0.tgz",
-      "integrity": "sha512-gDr4euVY5PUx2KrEhEUJtSWbO2GiKIKMK8PEkBi3dlJg4qWWSiTYEy1J3N7apbaCdUSoXEOn6QdOQkNWP/wW4w==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-tc/-/eslint-config-tc-12.1.0.tgz",
+      "integrity": "sha512-JNk9GpBCqHhm1nuY6GN/16Drjw+L0Yem14gHEY8Xw/X7YK2q8IMcXx1jIh1XwMP452fJJhF8n7PlVPE8hyovMQ==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "^14.0.0",
-        "eslint-config-prettier": "^6.10.0"
+        "eslint-config-airbnb-base": "^14.1.0",
+        "eslint-config-prettier": "^6.10.1"
       }
     },
     "eslint-formatter-pretty": {
@@ -5779,9 +5779,9 @@
       }
     },
     "npm-package-json-lint-config-tc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-tc/-/npm-package-json-lint-config-tc-3.0.0.tgz",
-      "integrity": "sha512-fOCKjZc+lKTI4nk9IdemBXi8nXFmfOMwTduMrWpTi2tt1i2pR0d6Cxgt8D54httjpSRato72dsGo0d027etmXg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-tc/-/npm-package-json-lint-config-tc-4.0.0.tgz",
+      "integrity": "sha512-e6CFWeQyM6jw5eqb0Ds/7HFdyrySE7ZDbQ8BXS5zJEmcxg+heiCiX14ZSp3dCwDDXA5ZaMdgukOB5sNVU3k1Qw==",
       "dev": true
     },
     "npm-run-path": {
@@ -6103,9 +6103,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "eslint": "^6.8.0",
-    "eslint-config-tc": "^11.0.0",
+    "eslint-config-tc": "^12.1.0",
     "eslint-formatter-pretty": "^3.0.1",
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.20.2",
@@ -41,11 +41,11 @@
     "eslint-plugin-prettier": "^3.1.3",
     "jest": "^25.3.0",
     "npm-package-json-lint": "^5.0.0",
-    "npm-package-json-lint-config-tc": "^3.0.0",
-    "prettier": "^1.19.1"
+    "npm-package-json-lint-config-tc": "^4.0.0",
+    "prettier": "^2.0.4"
   },
   "engines": {
-    "node": ">=8.0.0",
+    "node": ">=10.0.0",
     "npm": ">=6.0.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-releases-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Sentry.io releases for GitHub Actions",
   "keywords": [
     "actions",

--- a/src/create-release.js
+++ b/src/create-release.js
@@ -8,10 +8,11 @@ const run = async () => {
 
     // Get the inputs from the workflow file: https://github.com/actions/toolkit/tree/master/packages/core#inputsoutputs
     const tagName = core.getInput('tagName', {
-      required: true
+      required: true,
     });
     const environment = core.getInput('environment', {
-      required: true
+      required: true,
+    });
     });
 
     // This removes the 'refs/tags' portion of the string, i.e. from 'refs/tags/v1.0.0' to 'v1.0.0'
@@ -24,7 +25,7 @@ const run = async () => {
     // Set commits
     await cli.releases.setCommits(tag, {
       repo: 'repo',
-      auto: true
+      auto: true,
     });
 
     // Create a deployment (A node.js function isn't exposed for this operation.)

--- a/src/runCommand.js
+++ b/src/runCommand.js
@@ -1,5 +1,6 @@
 const {execFile} = require('child_process');
 
+// eslint-disable-next-line require-await
 const runCommand = async (filePath, args) => {
   return new Promise((resolve, reject) => {
     execFile(filePath, args, (error, stdout) => {
@@ -13,5 +14,5 @@ const runCommand = async (filePath, args) => {
 };
 
 module.exports = {
-  runCommand
+  runCommand,
 };

--- a/test/create-release.test.js
+++ b/test/create-release.test.js
@@ -8,7 +8,7 @@ jest.mock('@sentry/cli', () => jest.fn());
 jest.mock('../src/runCommand');
 
 describe('create-release', () => {
-  test('happy path', async () => {
+  test('No releaseNamePrefix', async () => {
     const finalize = jest.fn().mockResolvedValue('done');
     const newMock = jest.fn().mockResolvedValue('done');
     const setCommits = jest.fn().mockResolvedValue('done');
@@ -51,6 +51,56 @@ describe('create-release', () => {
 
     expect(finalize).toHaveBeenCalledTimes(1);
     expect(finalize).toHaveBeenCalledWith('v1.0.0');
+
+    expect(core.setFailed).toHaveBeenCalledTimes(0);
+  });
+
+  test('releaseNamePrefix set', async () => {
+    const finalize = jest.fn().mockResolvedValue('done');
+    const newMock = jest.fn().mockResolvedValue('done');
+    const setCommits = jest.fn().mockResolvedValue('done');
+    const getPath = jest.fn().mockReturnValue('sentryCliPath');
+    const repo = 'repo';
+
+    SentryCli.mockImplementation(() => {
+      return {
+        releases: {
+          finalize,
+          new: newMock,
+          setCommits,
+        },
+      };
+    });
+    SentryCli.getPath = getPath;
+    core.getInput
+      .mockReturnValueOnce('refs/tags/v1.0.0')
+      .mockReturnValueOnce('qa')
+      .mockReturnValueOnce('myAwesomeProject-');
+    runCommand.runCommand.mockResolvedValue('done');
+
+    await run();
+
+    expect(newMock).toHaveBeenCalledTimes(1);
+    expect(newMock).toHaveBeenCalledWith('myAwesomeProject-v1.0.0');
+
+    expect(setCommits).toHaveBeenCalledTimes(1);
+    expect(setCommits).toHaveBeenCalledWith('myAwesomeProject-v1.0.0', {
+      repo,
+      auto: true,
+    });
+
+    expect(runCommand.runCommand).toHaveBeenCalledTimes(1);
+    expect(runCommand.runCommand).toHaveBeenCalledWith('sentryCliPath', [
+      'releases',
+      'deploys',
+      'myAwesomeProject-v1.0.0',
+      'new',
+      '-e',
+      'qa',
+    ]);
+
+    expect(finalize).toHaveBeenCalledTimes(1);
+    expect(finalize).toHaveBeenCalledWith('myAwesomeProject-v1.0.0');
 
     expect(core.setFailed).toHaveBeenCalledTimes(0);
   });

--- a/test/create-release.test.js
+++ b/test/create-release.test.js
@@ -20,8 +20,8 @@ describe('create-release', () => {
         releases: {
           finalize,
           new: newMock,
-          setCommits
-        }
+          setCommits,
+        },
       };
     });
     SentryCli.getPath = getPath;
@@ -36,7 +36,7 @@ describe('create-release', () => {
     expect(setCommits).toHaveBeenCalledTimes(1);
     expect(setCommits).toHaveBeenCalledWith('v1.0.0', {
       repo,
-      auto: true
+      auto: true,
     });
 
     expect(runCommand.runCommand).toHaveBeenCalledTimes(1);
@@ -46,7 +46,7 @@ describe('create-release', () => {
       'v1.0.0',
       'new',
       '-e',
-      'qa'
+      'qa',
     ]);
 
     expect(finalize).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Add support for optionally prefixing tags when generating the Sentry release name. See docs in diff for more details. 