### PR TITLE
Add source map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Create a workflow `.yml` file in your repo's `.github/workflows` directory. An [
 
 For more information on these inputs, see the [API Documentation](https://developer.github.com/v3/repos/releases/#input)
 
+#### `sourceMapOptions`
+
+**Optional** A JSON object containing options to control [source map uploading](https://docs.sentry.io/cli/releases/#sentry-cli-sourcemaps).
+
+Refer to [Sentry's CLI JS](https://github.com/getsentry/sentry-cli/blob/1f5cdbb6897e41a7e9a3892aea3b34b4c0341207/js/releases/index.js#L114-L144) for possible values. The only required value is `include` which is an array of paths to upload source maps from.
+
 ### Environment Variables
 
 #### `SENTRY_AUTH_TOKEN`

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   releaseNamePrefix:
     description: 'String to prefix tagName with. Used as the Sentry release name.'
     required: false
+  sourceMapOptions:
+    description: 'Options for source map uploading. Must be provided as JSON. Refer to Sentry CLI docs for available parameters.'
+    required: false
+
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -19,7 +19,13 @@ module.exports =
 /******/ 		};
 /******/
 /******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete installedModules[moduleId];
+/******/ 		}
 /******/
 /******/ 		// Flag the module as loaded
 /******/ 		module.l = true;
@@ -34,7 +40,7 @@ module.exports =
 /******/ 	// the startup function
 /******/ 	function startup() {
 /******/ 		// Load entry module and return exports
-/******/ 		return __webpack_require__(703);
+/******/ 		return __webpack_require__(270);
 /******/ 	};
 /******/
 /******/ 	// run startup
@@ -43,204 +49,12 @@ module.exports =
 /************************************************************************/
 /******/ ({
 
-/***/ 87:
-/***/ (function(module) {
-
-module.exports = require("os");
-
-/***/ }),
-
-/***/ 116:
+/***/ 82:
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
-"use strict";
-
-
-const os = __webpack_require__(87);
-const path = __webpack_require__(622);
-const childProcess = __webpack_require__(129);
-
-/**
- * Absolute path to the sentry-cli binary (platform dependant).
- * @type {string}
- */
-// istanbul ignore next
-let binaryPath = __webpack_require__.ab + "sentry-cli";
-/**
- * Overrides the default binary path with a mock value, useful for testing.
- *
- * @param {string} mockPath The new path to the mock sentry-cli binary
- */
-function mockBinaryPath(mockPath) {
-  binaryPath = mockPath;
-}
-
-/**
- * The javascript type of a command line option.
- * @typedef {'array'|'string'|'boolean'|'inverted-boolean'} OptionType
- */
-
-/**
- * Schema definition of a command line option.
- * @typedef {object} OptionSchema
- * @prop {string} param The flag of the command line option including dashes.
- * @prop {OptionType} type The value type of the command line option.
- */
-
-/**
- * Schema definition for a command.
- * @typedef {Object.<string, OptionSchema>} OptionsSchema
- */
-
-/**
- * Serializes command line options into an arguments array.
- *
- * @param {OptionsSchema} schema An options schema required by the command.
- * @param {object} options An options object according to the schema.
- * @returns {string[]} An arguments array that can be passed via command line.
- */
-function serializeOptions(schema, options) {
-  return Object.keys(schema).reduce((newOptions, option) => {
-    const paramValue = options[option];
-    if (paramValue === undefined) {
-      return newOptions;
-    }
-
-    const paramType = schema[option].type;
-    const paramName = schema[option].param;
-
-    if (paramType === 'array') {
-      if (!Array.isArray(paramValue)) {
-        throw new Error(`${option} should be an array`);
-      }
-
-      return newOptions.concat(
-        paramValue.reduce((acc, value) => acc.concat([paramName, String(value)]), [])
-      );
-    }
-
-    if (paramType === 'boolean') {
-      if (typeof paramValue !== 'boolean') {
-        throw new Error(`${option} should be a bool`);
-      }
-
-      const invertedParamName = schema[option].invertedParam;
-
-      if (paramValue && paramName !== undefined) {
-        return newOptions.concat([paramName]);
-      }
-
-      if (!paramValue && invertedParamName !== undefined) {
-        return newOptions.concat([invertedParamName]);
-      }
-
-      return newOptions;
-    }
-
-    return newOptions.concat(paramName, paramValue);
-  }, []);
-}
-
-/**
- * Serializes the command and its options into an arguments array.
- *
- * @param {string} command The literal name of the command.
- * @param {OptionsSchema} [schema] An options schema required by the command.
- * @param {object} [options] An options object according to the schema.
- * @returns {string[]} An arguments array that can be passed via command line.
- */
-function prepareCommand(command, schema, options) {
-  return command.concat(serializeOptions(schema || {}, options || {}));
-}
-
-/**
- * Returns the absolute path to the `sentry-cli` binary.
- * @returns {string}
- */
-function getPath() {
-  return __webpack_require__.ab + "sentry-cli";
-}
-
-/**
- * Runs `sentry-cli` with the given command line arguments.
- *
- * Use {@link prepareCommand} to specify the command and add arguments for command-
- * specific options. For top-level options, use {@link serializeOptions} directly.
- *
- * The returned promise resolves with the standard output of the command invocation
- * including all newlines. In order to parse this output, be sure to trim the output
- * first.
- *
- * If the command failed to execute, the Promise rejects with the error returned by the
- * CLI. This error includes a `code` property with the process exit status.
- *
- * @example
- * const output = await execute(['--version']);
- * expect(output.trim()).toBe('sentry-cli x.y.z');
- *
- * @param {string[]} args Command line arguments passed to `sentry-cli`.
- * @param {boolean} live We inherit stdio to display `sentry-cli` output directly.
- * @param {boolean} silent Disable stdout for silents build (CI/Webpack Stats, ...)
- * @param {string} [configFile] Relative or absolute path to the configuration file.
- * @returns {Promise.<string>} A promise that resolves to the standard output.
- */
-function execute(args, live, silent, configFile) {
-  const env = Object.assign({}, process.env);
-  if (configFile) {
-    env.SENTRY_PROPERTIES = configFile;
-  }
-  return new Promise((resolve, reject) => {
-    if (live === true) {
-      const pid = childProcess.spawn(getPath(), args, {
-        env,
-        stdio: ['inherit', silent ? 'pipe' : 'inherit', 'inherit'],
-      });
-      pid.on('exit', () => {
-        resolve();
-      });
-    } else {
-      childProcess.execFile(getPath(), args, { env }, (err, stdout) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(stdout);
-        }
-      });
-    }
-  });
-}
-
-module.exports = {
-  mockBinaryPath,
-  serializeOptions,
-  prepareCommand,
-  getPath,
-  execute,
-};
-
-
-/***/ }),
-
-/***/ 129:
-/***/ (function(module) {
-
-module.exports = require("child_process");
-
-/***/ }),
-
-/***/ 180:
-/***/ (function(module) {
-
-module.exports = {"_args":[["@sentry/cli@1.52.1","/Users/thomaslindner/git/sentry-releases-action"]],"_from":"@sentry/cli@1.52.1","_id":"@sentry/cli@1.52.1","_inBundle":false,"_integrity":"sha512-XocAy3opa7bxWEbYQ9R/whbIb4BAX2YHXvfMoCwZRzLRy9cf85FYGQCMi8JA7wQd5PBmcxUh31AxcX7jAfMPCQ==","_location":"/@sentry/cli","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@sentry/cli@1.52.1","name":"@sentry/cli","escapedName":"@sentry%2fcli","scope":"@sentry","rawSpec":"1.52.1","saveSpec":null,"fetchSpec":"1.52.1"},"_requiredBy":["/"],"_resolved":"https://registry.npmjs.org/@sentry/cli/-/cli-1.52.1.tgz","_spec":"1.52.1","_where":"/Users/thomaslindner/git/sentry-releases-action","bin":{"sentry-cli":"bin/sentry-cli"},"bugs":{"url":"https://github.com/getsentry/sentry-cli/issues"},"dependencies":{"fs-copy-file-sync":"^1.1.1","https-proxy-agent":"^4.0.0","mkdirp":"^0.5.4","node-fetch":"^2.1.2","progress":"2.0.0","proxy-from-env":"^1.0.0"},"description":"A command line utility to work with Sentry. https://docs.sentry.io/hosted/learn/cli/","devDependencies":{"eslint":"^4.19.1","eslint-config-airbnb-base":"^12.1.0","eslint-config-prettier":"^2.9.0","eslint-plugin-import":"^2.12.0","jest":"^21.2.1","npm-run-all":"^4.1.3","prettier":"^1.13.4","prettier-check":"^2.0.0"},"engines":{"node":">= 8"},"homepage":"https://docs.sentry.io/hosted/learn/cli/","jest":{"collectCoverage":true,"testEnvironment":"node"},"keywords":["sentry","sentry-cli","cli"],"license":"BSD-3-Clause","main":"js/index.js","name":"@sentry/cli","repository":{"type":"git","url":"git+https://github.com/getsentry/sentry-cli.git"},"scripts":{"fix":"npm-run-all fix:eslint fix:prettier","fix:eslint":"eslint --fix \"bin/*\" js","fix:prettier":"prettier --write \"bin/*\" \"scripts/*.js\" \"js/**/*.js\"","install":"node scripts/install.js","test":"npm-run-all test:jest test:eslint test:prettier","test:eslint":"eslint bin scripts js","test:jest":"jest","test:prettier":"prettier-check \"bin/*\" \"scripts/*.js\" \"js/**/*.js\"","test:watch":"jest --watch --notify"},"version":"1.52.1"};
-
-/***/ }),
-
-/***/ 270:
-/***/ (function(module, __unusedexports, __webpack_require__) {
-
-const core = __webpack_require__(310);
-const SentryCli = __webpack_require__(340);
-const {runCommand} = __webpack_require__(737);
+const core = __webpack_require__(438);
+const SentryCli = __webpack_require__(433);
+const {runCommand} = __webpack_require__(828);
 
 const run = async () => {
   try {
@@ -277,6 +91,16 @@ const run = async () => {
       auto: true,
     });
 
+    /* istanbul ignore next */
+    const sourceMapOptions = core.getInput('sourceMapOptions', {
+      required: false,
+    });
+
+    /* istanbul ignore next */
+    if (sourceMapOptions) {
+      await cli.releases.uploadSourceMaps(releaseName, JSON.parse(sourceMapOptions));
+    }
+
     // Create a deployment (A node.js function isn't exposed for this operation.)
     const sentryCliPath = SentryCli.getPath();
 
@@ -295,359 +119,39 @@ module.exports = run;
 
 /***/ }),
 
-/***/ 310:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
-
-"use strict";
-
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const command_1 = __webpack_require__(997);
-const os = __importStar(__webpack_require__(87));
-const path = __importStar(__webpack_require__(622));
-/**
- * The code to exit an action
- */
-var ExitCode;
-(function (ExitCode) {
-    /**
-     * A code indicating that the action was successful
-     */
-    ExitCode[ExitCode["Success"] = 0] = "Success";
-    /**
-     * A code indicating that the action was a failure
-     */
-    ExitCode[ExitCode["Failure"] = 1] = "Failure";
-})(ExitCode = exports.ExitCode || (exports.ExitCode = {}));
-//-----------------------------------------------------------------------
-// Variables
-//-----------------------------------------------------------------------
-/**
- * Sets env variable for this action and future actions in the job
- * @param name the name of the variable to set
- * @param val the value of the variable
- */
-function exportVariable(name, val) {
-    process.env[name] = val;
-    command_1.issueCommand('set-env', { name }, val);
-}
-exports.exportVariable = exportVariable;
-/**
- * Registers a secret which will get masked from logs
- * @param secret value of the secret
- */
-function setSecret(secret) {
-    command_1.issueCommand('add-mask', {}, secret);
-}
-exports.setSecret = setSecret;
-/**
- * Prepends inputPath to the PATH (for this action and future actions)
- * @param inputPath
- */
-function addPath(inputPath) {
-    command_1.issueCommand('add-path', {}, inputPath);
-    process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
-}
-exports.addPath = addPath;
-/**
- * Gets the value of an input.  The value is also trimmed.
- *
- * @param     name     name of the input to get
- * @param     options  optional. See InputOptions.
- * @returns   string
- */
-function getInput(name, options) {
-    const val = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || '';
-    if (options && options.required && !val) {
-        throw new Error(`Input required and not supplied: ${name}`);
-    }
-    return val.trim();
-}
-exports.getInput = getInput;
-/**
- * Sets the value of an output.
- *
- * @param     name     name of the output to set
- * @param     value    value to store
- */
-function setOutput(name, value) {
-    command_1.issueCommand('set-output', { name }, value);
-}
-exports.setOutput = setOutput;
-//-----------------------------------------------------------------------
-// Results
-//-----------------------------------------------------------------------
-/**
- * Sets the action status to failed.
- * When the action exits it will be with an exit code of 1
- * @param message add error issue message
- */
-function setFailed(message) {
-    process.exitCode = ExitCode.Failure;
-    error(message);
-}
-exports.setFailed = setFailed;
-//-----------------------------------------------------------------------
-// Logging Commands
-//-----------------------------------------------------------------------
-/**
- * Gets whether Actions Step Debug is on or not
- */
-function isDebug() {
-    return process.env['RUNNER_DEBUG'] === '1';
-}
-exports.isDebug = isDebug;
-/**
- * Writes debug message to user log
- * @param message debug message
- */
-function debug(message) {
-    command_1.issueCommand('debug', {}, message);
-}
-exports.debug = debug;
-/**
- * Adds an error issue
- * @param message error issue message
- */
-function error(message) {
-    command_1.issue('error', message);
-}
-exports.error = error;
-/**
- * Adds an warning issue
- * @param message warning issue message
- */
-function warning(message) {
-    command_1.issue('warning', message);
-}
-exports.warning = warning;
-/**
- * Writes info to log with console.log.
- * @param message info message
- */
-function info(message) {
-    process.stdout.write(message + os.EOL);
-}
-exports.info = info;
-/**
- * Begin an output group.
- *
- * Output until the next `groupEnd` will be foldable in this group
- *
- * @param name The name of the output group
- */
-function startGroup(name) {
-    command_1.issue('group', name);
-}
-exports.startGroup = startGroup;
-/**
- * End an output group.
- */
-function endGroup() {
-    command_1.issue('endgroup');
-}
-exports.endGroup = endGroup;
-/**
- * Wrap an asynchronous function call in a group.
- *
- * Returns the same type as the function itself.
- *
- * @param name The name of the group
- * @param fn The function to wrap in the group
- */
-function group(name, fn) {
-    return __awaiter(this, void 0, void 0, function* () {
-        startGroup(name);
-        let result;
-        try {
-            result = yield fn();
-        }
-        finally {
-            endGroup();
-        }
-        return result;
-    });
-}
-exports.group = group;
-//-----------------------------------------------------------------------
-// Wrapper action state
-//-----------------------------------------------------------------------
-/**
- * Saves state for current action, the state can only be retrieved by this action's post job execution.
- *
- * @param     name     name of the state to store
- * @param     value    value to store
- */
-function saveState(name, value) {
-    command_1.issueCommand('save-state', { name }, value);
-}
-exports.saveState = saveState;
-/**
- * Gets the value of an state set by this action's main execution.
- *
- * @param     name     name of the state to get
- * @returns   string
- */
-function getState(name) {
-    return process.env[`STATE_${name}`] || '';
-}
-exports.getState = getState;
-//# sourceMappingURL=core.js.map
-
-/***/ }),
-
-/***/ 340:
-/***/ (function(module, __unusedexports, __webpack_require__) {
-
-"use strict";
-
-
-const pkgInfo = __webpack_require__(180);
-const helper = __webpack_require__(116);
-const Releases = __webpack_require__(466);
-
-/**
- * Interface to and wrapper around the `sentry-cli` executable.
- *
- * Commands are grouped into namespaces. See the respective namespaces for more
- * documentation. To use this wrapper, simply create an instance and call methods:
- *
- * @example
- * const cli = new SentryCli();
- * console.log(cli.getVersion());
- *
- * @example
- * const cli = new SentryCli('path/to/custom/sentry.properties');
- * console.log(cli.getVersion());
- */
-class SentryCli {
-  /**
-   * Creates a new `SentryCli` instance.
-   *
-   * If the `configFile` parameter is specified, configuration located in the default
-   * location and the value specified in the `SENTRY_PROPERTIES` environment variable is
-   * overridden.
-   *
-   * @param {string} [configFile] Relative or absolute path to the configuration file.
-   * @param {Object} [options] More options to pass to the CLI
-   */
-  constructor(configFile, options) {
-    if (typeof configFile === 'string') {
-      this.configFile = configFile;
-    }
-    this.options = options || { silent: false };
-
-    this.releases = new Releases(Object.assign({}, this.options, { configFile }));
-  }
-
-  /**
-   * Returns the version of the installed `sentry-cli` binary.
-   * @returns {string}
-   */
-  static getVersion() {
-    return pkgInfo.version;
-  }
-
-  /**
-   * Returns an absolute path to the `sentry-cli` binary.
-   * @returns {string}
-   */
-  static getPath() {
-    return helper.getPath();
-  }
-
-  /**
-   * See {helper.execute} docs.
-   * @param {string[]} args Command line arguments passed to `sentry-cli`.
-   * @param {boolean} live We inherit stdio to display `sentry-cli` output directly.
-   * @returns {Promise.<string>} A promise that resolves to the standard output.
-   */
-  execute(args, live) {
-    return helper.execute(args, live, this.options.silent, this.configFile);
-  }
-}
-
-module.exports = SentryCli;
-
-
-/***/ }),
-
-/***/ 355:
+/***/ 87:
 /***/ (function(module) {
 
-module.exports = {
-  ignore: {
-    param: '--ignore',
-    type: 'array',
-  },
-  ignoreFile: {
-    param: '--ignore-file',
-    type: 'string',
-  },
-  dist: {
-    param: '--dist',
-    type: 'string',
-  },
-  rewrite: {
-    param: '--rewrite',
-    invertedParam: '--no-rewrite',
-    type: 'boolean',
-  },
-  sourceMapReference: {
-    invertedParam: '--no-sourcemap-reference',
-    type: 'boolean',
-  },
-  stripPrefix: {
-    param: '--strip-prefix',
-    type: 'array',
-  },
-  stripCommonPrefix: {
-    param: '--strip-common-prefix',
-    type: 'boolean',
-  },
-  validate: {
-    param: '--validate',
-    type: 'boolean',
-  },
-  urlPrefix: {
-    param: '--url-prefix',
-    type: 'string',
-  },
-  urlSuffix: {
-    param: '--url-suffix',
-    type: 'string',
-  },
-  ext: {
-    param: '--ext',
-    type: 'array',
-  },
-};
+module.exports = require("os");
+
+/***/ }),
+
+/***/ 129:
+/***/ (function(module) {
+
+module.exports = require("child_process");
+
+/***/ }),
+
+/***/ 270:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const run = __webpack_require__(82);
+
+if (require.main === require.cache[eval('__filename')]) {
+  run();
+}
 
 
 /***/ }),
 
-/***/ 466:
+/***/ 357:
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-const helper = __webpack_require__(116);
+const helper = __webpack_require__(572);
 
 /**
  * Default arguments for the `--ignore` option.
@@ -659,7 +163,13 @@ const DEFAULT_IGNORE = ['node_modules'];
  * Schema for the `upload-sourcemaps` command.
  * @type {OptionsSchema}
  */
-const SOURCEMAPS_SCHEMA = __webpack_require__(355);
+const SOURCEMAPS_SCHEMA = __webpack_require__(467);
+
+/**
+ * Schema for the `deploys new` command.
+ * @type {OptionsSchema}
+ */
+const DEPLOYS_SCHEMA = __webpack_require__(818);
 
 /**
  * Manages releases and release artifacts on Sentry.
@@ -789,7 +299,7 @@ class Releases {
     }
 
     const uploads = options.include.map(sourcemapPath => {
-      const newOptions = Object.assign({}, options);
+      const newOptions = { ...options };
       if (!newOptions.ignoreFile && !newOptions.ignore) {
         newOptions.ignore = DEFAULT_IGNORE;
       }
@@ -799,6 +309,47 @@ class Releases {
     });
 
     return Promise.all(uploads);
+  }
+
+  /**
+   * List all deploys for a given release.
+   *
+   * @param {string} release Unique name of the release.
+   * @returns {Promise} A promise that resolves when the list comes back from the server.
+   * @memberof SentryReleases
+   */
+  listDeploys(release) {
+    return this.execute(['releases', 'deploys', release, 'list'], null);
+  }
+
+  /**
+   * Creates a new release deployment. This should be called after the release has been
+   * finalized, while deploying on a given environment.
+   *
+   * @example
+   * await cli.releases.newDeploy(cli.releases.proposeVersion(), {
+   *   // required options:
+   *   env: 'production',          // environment for this release. Values that make sense here would be 'production' or 'staging'
+   *
+   *   // optional options:
+   *   started: 42,                // unix timestamp when the deployment started
+   *   finished: 1337,             // unix timestamp when the deployment finished
+   *   time: 1295,                 // deployment duration in seconds. This can be specified alternatively to `started` and `finished`
+   *   name: 'PickleRick',         // human readable name for this deployment
+   *   url: 'https://example.com', // URL that points to the deployment
+   * });
+   *
+   * @param {string} release Unique name of the release.
+   * @param {object} options Options to configure the new release deploy.
+   * @returns {Promise} A promise that resolves when the deploy has been created.
+   * @memberof SentryReleases
+   */
+  newDeploy(release, options) {
+    if (!options || !options.include) {
+      throw new Error('options.env must be a vaild name');
+    }
+    const args = ['releases', 'deploys', release, 'new'];
+    return this.execute(helper.prepareCommand(args, DEPLOYS_SCHEMA, options), null);
   }
 
   /**
@@ -817,51 +368,365 @@ module.exports = Releases;
 
 /***/ }),
 
-/***/ 622:
-/***/ (function(module) {
-
-module.exports = require("path");
-
-/***/ }),
-
-/***/ 703:
-/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
-
-const run = __webpack_require__(270);
-
-if (require.main === require.cache[eval('__filename')]) {
-  run();
-}
-
-
-/***/ }),
-
-/***/ 737:
+/***/ 433:
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
-const {execFile} = __webpack_require__(129);
+"use strict";
 
-// eslint-disable-next-line require-await
-const runCommand = async (filePath, args) => {
-  return new Promise((resolve, reject) => {
-    execFile(filePath, args, (error, stdout) => {
-      if (error) {
-        reject(error);
-      }
 
-      resolve(stdout);
+const pkgInfo = __webpack_require__(597);
+const helper = __webpack_require__(572);
+const Releases = __webpack_require__(357);
+
+/**
+ * Interface to and wrapper around the `sentry-cli` executable.
+ *
+ * Commands are grouped into namespaces. See the respective namespaces for more
+ * documentation. To use this wrapper, simply create an instance and call methods:
+ *
+ * @example
+ * const cli = new SentryCli();
+ * console.log(cli.getVersion());
+ *
+ * @example
+ * const cli = new SentryCli('path/to/custom/sentry.properties');
+ * console.log(cli.getVersion());
+ */
+class SentryCli {
+  /**
+   * Creates a new `SentryCli` instance.
+   *
+   * If the `configFile` parameter is specified, configuration located in the default
+   * location and the value specified in the `SENTRY_PROPERTIES` environment variable is
+   * overridden.
+   *
+   * @param {string} [configFile] Relative or absolute path to the configuration file.
+   * @param {Object} [options] More options to pass to the CLI
+   */
+  constructor(configFile, options) {
+    if (typeof configFile === 'string') {
+      this.configFile = configFile;
+    }
+    this.options = options || { silent: false };
+    this.releases = new Releases({ ...this.options, configFile });
+  }
+
+  /**
+   * Returns the version of the installed `sentry-cli` binary.
+   * @returns {string}
+   */
+  static getVersion() {
+    return pkgInfo.version;
+  }
+
+  /**
+   * Returns an absolute path to the `sentry-cli` binary.
+   * @returns {string}
+   */
+  static getPath() {
+    return helper.getPath();
+  }
+
+  /**
+   * See {helper.execute} docs.
+   * @param {string[]} args Command line arguments passed to `sentry-cli`.
+   * @param {boolean} live We inherit stdio to display `sentry-cli` output directly.
+   * @returns {Promise.<string>} A promise that resolves to the standard output.
+   */
+  execute(args, live) {
+    return helper.execute(args, live, this.options.silent, this.configFile);
+  }
+}
+
+module.exports = SentryCli;
+
+
+/***/ }),
+
+/***/ 438:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
-  });
 };
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const command_1 = __webpack_require__(544);
+const os = __importStar(__webpack_require__(87));
+const path = __importStar(__webpack_require__(622));
+/**
+ * The code to exit an action
+ */
+var ExitCode;
+(function (ExitCode) {
+    /**
+     * A code indicating that the action was successful
+     */
+    ExitCode[ExitCode["Success"] = 0] = "Success";
+    /**
+     * A code indicating that the action was a failure
+     */
+    ExitCode[ExitCode["Failure"] = 1] = "Failure";
+})(ExitCode = exports.ExitCode || (exports.ExitCode = {}));
+//-----------------------------------------------------------------------
+// Variables
+//-----------------------------------------------------------------------
+/**
+ * Sets env variable for this action and future actions in the job
+ * @param name the name of the variable to set
+ * @param val the value of the variable. Non-string values will be converted to a string via JSON.stringify
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function exportVariable(name, val) {
+    const convertedVal = command_1.toCommandValue(val);
+    process.env[name] = convertedVal;
+    command_1.issueCommand('set-env', { name }, convertedVal);
+}
+exports.exportVariable = exportVariable;
+/**
+ * Registers a secret which will get masked from logs
+ * @param secret value of the secret
+ */
+function setSecret(secret) {
+    command_1.issueCommand('add-mask', {}, secret);
+}
+exports.setSecret = setSecret;
+/**
+ * Prepends inputPath to the PATH (for this action and future actions)
+ * @param inputPath
+ */
+function addPath(inputPath) {
+    command_1.issueCommand('add-path', {}, inputPath);
+    process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
+}
+exports.addPath = addPath;
+/**
+ * Gets the value of an input.  The value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string
+ */
+function getInput(name, options) {
+    const val = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || '';
+    if (options && options.required && !val) {
+        throw new Error(`Input required and not supplied: ${name}`);
+    }
+    return val.trim();
+}
+exports.getInput = getInput;
+/**
+ * Sets the value of an output.
+ *
+ * @param     name     name of the output to set
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setOutput(name, value) {
+    command_1.issueCommand('set-output', { name }, value);
+}
+exports.setOutput = setOutput;
+/**
+ * Enables or disables the echoing of commands into stdout for the rest of the step.
+ * Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
+ *
+ */
+function setCommandEcho(enabled) {
+    command_1.issue('echo', enabled ? 'on' : 'off');
+}
+exports.setCommandEcho = setCommandEcho;
+//-----------------------------------------------------------------------
+// Results
+//-----------------------------------------------------------------------
+/**
+ * Sets the action status to failed.
+ * When the action exits it will be with an exit code of 1
+ * @param message add error issue message
+ */
+function setFailed(message) {
+    process.exitCode = ExitCode.Failure;
+    error(message);
+}
+exports.setFailed = setFailed;
+//-----------------------------------------------------------------------
+// Logging Commands
+//-----------------------------------------------------------------------
+/**
+ * Gets whether Actions Step Debug is on or not
+ */
+function isDebug() {
+    return process.env['RUNNER_DEBUG'] === '1';
+}
+exports.isDebug = isDebug;
+/**
+ * Writes debug message to user log
+ * @param message debug message
+ */
+function debug(message) {
+    command_1.issueCommand('debug', {}, message);
+}
+exports.debug = debug;
+/**
+ * Adds an error issue
+ * @param message error issue message. Errors will be converted to string via toString()
+ */
+function error(message) {
+    command_1.issue('error', message instanceof Error ? message.toString() : message);
+}
+exports.error = error;
+/**
+ * Adds an warning issue
+ * @param message warning issue message. Errors will be converted to string via toString()
+ */
+function warning(message) {
+    command_1.issue('warning', message instanceof Error ? message.toString() : message);
+}
+exports.warning = warning;
+/**
+ * Writes info to log with console.log.
+ * @param message info message
+ */
+function info(message) {
+    process.stdout.write(message + os.EOL);
+}
+exports.info = info;
+/**
+ * Begin an output group.
+ *
+ * Output until the next `groupEnd` will be foldable in this group
+ *
+ * @param name The name of the output group
+ */
+function startGroup(name) {
+    command_1.issue('group', name);
+}
+exports.startGroup = startGroup;
+/**
+ * End an output group.
+ */
+function endGroup() {
+    command_1.issue('endgroup');
+}
+exports.endGroup = endGroup;
+/**
+ * Wrap an asynchronous function call in a group.
+ *
+ * Returns the same type as the function itself.
+ *
+ * @param name The name of the group
+ * @param fn The function to wrap in the group
+ */
+function group(name, fn) {
+    return __awaiter(this, void 0, void 0, function* () {
+        startGroup(name);
+        let result;
+        try {
+            result = yield fn();
+        }
+        finally {
+            endGroup();
+        }
+        return result;
+    });
+}
+exports.group = group;
+//-----------------------------------------------------------------------
+// Wrapper action state
+//-----------------------------------------------------------------------
+/**
+ * Saves state for current action, the state can only be retrieved by this action's post job execution.
+ *
+ * @param     name     name of the state to store
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function saveState(name, value) {
+    command_1.issueCommand('save-state', { name }, value);
+}
+exports.saveState = saveState;
+/**
+ * Gets the value of an state set by this action's main execution.
+ *
+ * @param     name     name of the state to get
+ * @returns   string
+ */
+function getState(name) {
+    return process.env[`STATE_${name}`] || '';
+}
+exports.getState = getState;
+//# sourceMappingURL=core.js.map
+
+/***/ }),
+
+/***/ 467:
+/***/ (function(module) {
 
 module.exports = {
-  runCommand,
+  ignore: {
+    param: '--ignore',
+    type: 'array',
+  },
+  ignoreFile: {
+    param: '--ignore-file',
+    type: 'string',
+  },
+  dist: {
+    param: '--dist',
+    type: 'string',
+  },
+  rewrite: {
+    param: '--rewrite',
+    invertedParam: '--no-rewrite',
+    type: 'boolean',
+  },
+  sourceMapReference: {
+    invertedParam: '--no-sourcemap-reference',
+    type: 'boolean',
+  },
+  stripPrefix: {
+    param: '--strip-prefix',
+    type: 'array',
+  },
+  stripCommonPrefix: {
+    param: '--strip-common-prefix',
+    type: 'boolean',
+  },
+  validate: {
+    param: '--validate',
+    type: 'boolean',
+  },
+  urlPrefix: {
+    param: '--url-prefix',
+    type: 'string',
+  },
+  urlSuffix: {
+    param: '--url-suffix',
+    type: 'string',
+  },
+  ext: {
+    param: '--ext',
+    type: 'array',
+  },
 };
 
 
 /***/ }),
 
-/***/ 997:
+/***/ 544:
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
@@ -928,14 +793,28 @@ class Command {
         return cmdStr;
     }
 }
+/**
+ * Sanitizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
+ */
+function toCommandValue(input) {
+    if (input === null || input === undefined) {
+        return '';
+    }
+    else if (typeof input === 'string' || input instanceof String) {
+        return input;
+    }
+    return JSON.stringify(input);
+}
+exports.toCommandValue = toCommandValue;
 function escapeData(s) {
-    return (s || '')
+    return toCommandValue(s)
         .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A');
 }
 function escapeProperty(s) {
-    return (s || '')
+    return toCommandValue(s)
         .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A')
@@ -943,6 +822,249 @@ function escapeProperty(s) {
         .replace(/,/g, '%2C');
 }
 //# sourceMappingURL=command.js.map
+
+/***/ }),
+
+/***/ 572:
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+"use strict";
+
+
+const os = __webpack_require__(87);
+const path = __webpack_require__(622);
+const childProcess = __webpack_require__(129);
+
+/**
+ * Absolute path to the sentry-cli binary (platform dependent).
+ * @type {string}
+ */
+// istanbul ignore next
+let binaryPath = __webpack_require__.ab + "sentry-cli";
+/**
+ * Overrides the default binary path with a mock value, useful for testing.
+ *
+ * @param {string} mockPath The new path to the mock sentry-cli binary
+ */
+function mockBinaryPath(mockPath) {
+  binaryPath = mockPath;
+}
+
+/**
+ * The javascript type of a command line option.
+ * @typedef {'array'|'string'|'boolean'|'inverted-boolean'} OptionType
+ */
+
+/**
+ * Schema definition of a command line option.
+ * @typedef {object} OptionSchema
+ * @prop {string} param The flag of the command line option including dashes.
+ * @prop {OptionType} type The value type of the command line option.
+ */
+
+/**
+ * Schema definition for a command.
+ * @typedef {Object.<string, OptionSchema>} OptionsSchema
+ */
+
+/**
+ * Serializes command line options into an arguments array.
+ *
+ * @param {OptionsSchema} schema An options schema required by the command.
+ * @param {object} options An options object according to the schema.
+ * @returns {string[]} An arguments array that can be passed via command line.
+ */
+function serializeOptions(schema, options) {
+  return Object.keys(schema).reduce((newOptions, option) => {
+    const paramValue = options[option];
+    if (paramValue === undefined) {
+      return newOptions;
+    }
+
+    const paramType = schema[option].type;
+    const paramName = schema[option].param;
+
+    if (paramType === 'array') {
+      if (!Array.isArray(paramValue)) {
+        throw new Error(`${option} should be an array`);
+      }
+
+      return newOptions.concat(
+        paramValue.reduce((acc, value) => acc.concat([paramName, String(value)]), [])
+      );
+    }
+
+    if (paramType === 'boolean') {
+      if (typeof paramValue !== 'boolean') {
+        throw new Error(`${option} should be a bool`);
+      }
+
+      const invertedParamName = schema[option].invertedParam;
+
+      if (paramValue && paramName !== undefined) {
+        return newOptions.concat([paramName]);
+      }
+
+      if (!paramValue && invertedParamName !== undefined) {
+        return newOptions.concat([invertedParamName]);
+      }
+
+      return newOptions;
+    }
+
+    return newOptions.concat(paramName, paramValue);
+  }, []);
+}
+
+/**
+ * Serializes the command and its options into an arguments array.
+ *
+ * @param {string} command The literal name of the command.
+ * @param {OptionsSchema} [schema] An options schema required by the command.
+ * @param {object} [options] An options object according to the schema.
+ * @returns {string[]} An arguments array that can be passed via command line.
+ */
+function prepareCommand(command, schema, options) {
+  return command.concat(serializeOptions(schema || {}, options || {}));
+}
+
+/**
+ * Returns the absolute path to the `sentry-cli` binary.
+ * @returns {string}
+ */
+function getPath() {
+  return __webpack_require__.ab + "sentry-cli";
+}
+
+/**
+ * Runs `sentry-cli` with the given command line arguments.
+ *
+ * Use {@link prepareCommand} to specify the command and add arguments for command-
+ * specific options. For top-level options, use {@link serializeOptions} directly.
+ *
+ * The returned promise resolves with the standard output of the command invocation
+ * including all newlines. In order to parse this output, be sure to trim the output
+ * first.
+ *
+ * If the command failed to execute, the Promise rejects with the error returned by the
+ * CLI. This error includes a `code` property with the process exit status.
+ *
+ * @example
+ * const output = await execute(['--version']);
+ * expect(output.trim()).toBe('sentry-cli x.y.z');
+ *
+ * @param {string[]} args Command line arguments passed to `sentry-cli`.
+ * @param {boolean} live We inherit stdio to display `sentry-cli` output directly.
+ * @param {boolean} silent Disable stdout for silents build (CI/Webpack Stats, ...)
+ * @param {string} [configFile] Relative or absolute path to the configuration file.
+ * @returns {Promise.<string>} A promise that resolves to the standard output.
+ */
+function execute(args, live, silent, configFile) {
+  const env = { ...process.env };
+  if (configFile) {
+    env.SENTRY_PROPERTIES = configFile;
+  }
+  return new Promise((resolve, reject) => {
+    if (live === true) {
+      const pid = childProcess.spawn(getPath(), args, {
+        env,
+        stdio: ['inherit', silent ? 'pipe' : 'inherit', 'inherit'],
+      });
+      pid.on('exit', () => {
+        resolve();
+      });
+    } else {
+      childProcess.execFile(getPath(), args, { env }, (err, stdout) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(stdout);
+        }
+      });
+    }
+  });
+}
+
+module.exports = {
+  mockBinaryPath,
+  serializeOptions,
+  prepareCommand,
+  getPath,
+  execute,
+};
+
+
+/***/ }),
+
+/***/ 597:
+/***/ (function(module) {
+
+module.exports = {"_args":[["@sentry/cli@1.53.0","/Users/robbiet480/Repos/Flatfile/sentry-releases-action"]],"_from":"@sentry/cli@1.53.0","_id":"@sentry/cli@1.53.0","_inBundle":false,"_integrity":"sha512-FgVR+AqPd1elj/HGTCg4FcQDVmIGwKGtaHDzHi2ipph9EOVYm6Ce0xYcHxYgKZuVyQMyg+zD5ZK3yHrB1AYlnw==","_location":"/@sentry/cli","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@sentry/cli@1.53.0","name":"@sentry/cli","escapedName":"@sentry%2fcli","scope":"@sentry","rawSpec":"1.53.0","saveSpec":null,"fetchSpec":"1.53.0"},"_requiredBy":["/"],"_resolved":"https://registry.npmjs.org/@sentry/cli/-/cli-1.53.0.tgz","_spec":"1.53.0","_where":"/Users/robbiet480/Repos/Flatfile/sentry-releases-action","bin":{"sentry-cli":"bin/sentry-cli"},"bugs":{"url":"https://github.com/getsentry/sentry-cli/issues"},"dependencies":{"https-proxy-agent":"^5.0.0","mkdirp":"^0.5.5","node-fetch":"^2.6.0","progress":"^2.0.3","proxy-from-env":"^1.1.0"},"description":"A command line utility to work with Sentry. https://docs.sentry.io/hosted/learn/cli/","devDependencies":{"eslint":"^6.8.0","eslint-config-airbnb-base":"^14.1.0","eslint-config-prettier":"^6.10.1","eslint-plugin-import":"^2.20.2","jest":"^25.3.0","npm-run-all":"^4.1.5","prettier":"^1.19.1"},"engines":{"node":">= 8"},"homepage":"https://docs.sentry.io/hosted/learn/cli/","jest":{"collectCoverage":true,"testEnvironment":"node"},"keywords":["sentry","sentry-cli","cli"],"license":"BSD-3-Clause","main":"js/index.js","name":"@sentry/cli","repository":{"type":"git","url":"git+https://github.com/getsentry/sentry-cli.git"},"scripts":{"fix":"npm-run-all fix:eslint fix:prettier","fix:eslint":"eslint --fix bin/* scripts/**/*.js js/**/*.js","fix:prettier":"prettier --write bin/* scripts/**/*.js js/**/*.js","install":"node scripts/install.js","test":"npm-run-all test:jest test:eslint test:prettier","test:eslint":"eslint bin/* scripts/**/*.js js/**/*.js","test:jest":"jest","test:prettier":"prettier --check  bin/* scripts/**/*.js js/**/*.js","test:watch":"jest --watch --notify"},"version":"1.53.0"};
+
+/***/ }),
+
+/***/ 622:
+/***/ (function(module) {
+
+module.exports = require("path");
+
+/***/ }),
+
+/***/ 818:
+/***/ (function(module) {
+
+module.exports = {
+  env: {
+    param: '--env',
+    type: 'string',
+  },
+  started: {
+    param: '--started',
+    type: 'number',
+  },
+  finished: {
+    param: '--finished',
+    type: 'number',
+  },
+  time: {
+    param: '--time',
+    type: 'number',
+  },
+  name: {
+    param: '--name',
+    type: 'string',
+  },
+  url: {
+    param: '--url',
+    type: 'string',
+  },
+};
+
+
+/***/ }),
+
+/***/ 828:
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+const {execFile} = __webpack_require__(129);
+
+// eslint-disable-next-line require-await
+const runCommand = async (filePath, args) => {
+  return new Promise((resolve, reject) => {
+    execFile(filePath, args, (error, stdout) => {
+      if (error) {
+        reject(error);
+      }
+
+      resolve(stdout);
+    });
+  });
+};
+
+module.exports = {
+  runCommand,
+};
+
 
 /***/ })
 

--- a/src/create-release.js
+++ b/src/create-release.js
@@ -37,6 +37,16 @@ const run = async () => {
       auto: true,
     });
 
+    /* istanbul ignore next */
+    const sourceMapOptions = core.getInput('sourceMapOptions', {
+      required: false,
+    });
+
+    /* istanbul ignore next */
+    if (sourceMapOptions) {
+      await cli.releases.uploadSourceMaps(releaseName, JSON.parse(sourceMapOptions));
+    }
+
     // Create a deployment (A node.js function isn't exposed for this operation.)
     const sentryCliPath = SentryCli.getPath();
 


### PR DESCRIPTION
This PR adds source map support. I've had to disable tests on the lines for now because it doesn't appear that Sentry CLI has JS test capability for source map uploading (the feature was only added 8 days ago so give them some time).