### PR TITLE
Update README.md to use github.sha instead of github.ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ env:
   SENTRY_ORG: myAwesomeOrg
   SENTRY_PROJECT: myAwesomeProject
 with:
-  tagName: ${{ github.ref }}
+  tagName: ${{ github.sha }}
   environment: qa
 ```
 
@@ -108,7 +108,7 @@ jobs:
           SENTRY_ORG: myAwesomeOrg
           SENTRY_PROJECT: myAwesomeProject
         with:
-          tagName: ${{ github.ref }}
+          tagName: ${{ github.sha }}
           environment: qa
 ```
 
@@ -139,7 +139,7 @@ jobs:
           SENTRY_ORG: myAwesomeOrg
           SENTRY_PROJECT: myAwesomeProject
         with:
-          tagName: ${{ github.ref }}
+          tagName: ${{ github.sha }}
           environment: qa
           releaseNamePrefix: myAwesomeProject-
 ```
@@ -175,7 +175,7 @@ jobs:
           SENTRY_ORG: myAwesomeOrg
           SENTRY_PROJECT: myAwesomeProject
         with:
-          tagName: ${{ github.ref }}
+          tagName: ${{ github.sha }}
           environment: qa
           releaseNamePrefix: myAwesomeProject-
           sourceMapOptions: '{"include": ["build"]}'


### PR DESCRIPTION
https://github.com/tclindner/sentry-releases-action/issues/48#issuecomment-602930396

This comment says its better to use `github.sha` rather than `github.ref` so we should really tell people to start with that in the Readme.