### PR TITLE
node14 is not available anymore in github actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
 
 runs:
-  using: 'node14'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'bookmark'


### PR DESCRIPTION
Update to node16 as expected by the last Github Action upgrade.